### PR TITLE
fix(_base.scss): fixes hash location bug with body positioning

### DIFF
--- a/source/stylesheets/base/_base.scss
+++ b/source/stylesheets/base/_base.scss
@@ -11,5 +11,4 @@ html {
 body {
   overflow: hidden;
   width: 100%;
-  position: relative;
 }


### PR DESCRIPTION
Within `_base.scss`, the `body` element is set to `position:relative`. This is causing an issue where when navigating to a hashed url such as `codelandconf.com/#tickets`, the modules above Tickets are now out of the window view and can't be scrolled to. Additionally, a large amount of whitespace populates at the bottom of the page. Removing `position:relative` fixes the issue. 

(top of page: cannot scroll further up)
![Screen Shot 2020-04-18 at 12 06 51 PM](https://user-images.githubusercontent.com/28884425/79642713-2aefd300-816d-11ea-8dc1-13a08408a6b0.png)


(bottom of page: white space below footer)
![Screen Shot 2020-04-18 at 12 06 40 PM](https://user-images.githubusercontent.com/28884425/79642726-3ba04900-816d-11ea-9a2a-e097e60ec75a.png)



