### PR TITLE
Fix mobile scaling

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8">
-    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="keywords" content="codenewbie, conference, programmer, coding,

--- a/source/stylesheets/lib/_sponsors.scss
+++ b/source/stylesheets/lib/_sponsors.scss
@@ -7,7 +7,10 @@
   top: -75px;
 
   &:before {
-    display: none;
+    height: 120%;
+    transform: rotate(2.5deg);
+    left: -60px;
+    top: -80px;
   }
 }
 

--- a/source/stylesheets/lib/_sponsors.scss
+++ b/source/stylesheets/lib/_sponsors.scss
@@ -7,10 +7,7 @@
   top: -75px;
 
   &:before {
-    height: 120%;
-    transform: rotate(2.5deg);
-    left: -60px;
-    top: -80px;
+    display: none;
   }
 }
 

--- a/source/stylesheets/lib/_sponsors.scss
+++ b/source/stylesheets/lib/_sponsors.scss
@@ -5,12 +5,14 @@
 .section-card.sponsors {
   background: white;
   top: -75px;
+  position: relative;
 
   &:before {
     height: 120%;
     transform: rotate(2.5deg);
     left: -60px;
     top: -80px;
+    background-color: white;
   }
 }
 


### PR DESCRIPTION
- closes #49 

### Changes:
- Removed `minimum-scale=1.0,maximum-scale=1.0,user-scalable=no` from `viewport` meta tag
- Set `position:relative` on the sponsors block
- Gave the `.section-card.sponsors:before` pseudo element a white background to match the sponsors block

### Notes:
That `.section-card.sponsors:before` pseudo element was what was causing the overflow. The other `section-card` blocks have `position:relative` set on each of them, so adding it to `.sponsors` was easy enough. I think a better solution would probably be to add `position:relative` to `.section-card` and remove it from the other sections, but that would touch a lot more files and it's possible (if unlikely) that there could be other ramifications.