### PR TITLE
Attach nav link event to <a> instead of <li>

### DIFF
--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -3,7 +3,7 @@ $(document).ready(function(){
     $(".nav-link--menu").toggleClass("active");
   });
 
-  $(".nav-link--item").on("click", function(e) {
+  $(".nav-link--item > a").on("click", function(e) {
     $(".nav-link--menu").removeClass("active");
   });
 


### PR DESCRIPTION
- closes #61

### Changes:
- Simply changed the event selector to use the `<a>` element.